### PR TITLE
parsing/formatting strings with QuarterlyDate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: julia
 julia:
 - 1.2
 - 1.4
+- 1.5
 - nightly
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This packages makes it easier to work with monthly or quarterly dates. It define
 	# Alternatively, use the MonthlyDate constructor:
 	julia> dtm = MonthlyDate(1990, 1)
 	# 1990m01
+	# Or it can also be parsed from a string by specifying a DateFormat:
+	julia> dtm = MonthlyDate("1990-1", dateformat"Y-m") # the second argument can also be omitted if the string satisifies ISODateFormat
+	# 1990m01
 	julia> dtm + Month(1)
 	# 1991m01
 	julia> Date(dtm)
@@ -32,6 +35,12 @@ This packages makes it easier to work with monthly or quarterly dates. It define
 	# Alternatively, use the QuarterlyDate constructor:
 	julia> dtq = QuarterlyDate(1990, 1)
 	# 1990q1
+	# It can also be constructed from a string, with 'q' as the code for quarter:
+	julia> dtq = QuarterlyDate("1990-1", "Y-q")
+	# 1990q1
+	# if the DateFormat doesn't contain 'q', the string will be parsed as Date and then converted to QuarterlyDate
+	julia> QuarterlyDate("1990-4","Y-m") 
+	# 1990q2
 	julia> dtq + Quarter(3)
 	# 1991q4
 	julia> Date(dtq)

--- a/src/MonthlyDates.jl
+++ b/src/MonthlyDates.jl
@@ -10,9 +10,6 @@ module MonthlyDates
         include("Quarter.jl")
     end
 
-    if isdefined(Dates, :quarter)
-        import Dates: quarter
-    end
 
     ##############################################################################
     ##
@@ -65,7 +62,6 @@ module MonthlyDates
     #accessor (only bigger periods)    
     Dates.month(dt::MonthlyDate) = 1 + rem(value(dt) - 1, 12)
     quarterofyear(dt::MonthlyDate) = quarterofyear(Date(dt))
-    quarter(dt::MonthlyDate) = (month(dt) - 1) ÷ 3 + 1
     Dates.year(dt::MonthlyDate) =  1 + div(value(dt) - 1, 12)
 
     Dates.Month(dt::MonthlyDate) = Month(month(dt))
@@ -184,7 +180,6 @@ module MonthlyDates
     #accessor (only bigger periods)
     Dates.month(dt::QuarterlyDate) = 3 * (quarterofyear(dt) - 1) + 1
     quarterofyear(dt::QuarterlyDate) = quarterofyear(Date(dt))
-    quarter(dt::QuarterlyDate) = (month(dt) - 1) ÷ 3 + 1
     Dates.year(dt::QuarterlyDate) = 1 + div(value(dt) - 1, 4)
     Quarter(dt::QuarterlyDate) = Quarter(quarterofyear(dt))
     Dates.Year(dt::QuarterlyDate) = Year(year(dt))
@@ -206,7 +201,7 @@ module MonthlyDates
     end
 
     function Dates.format(io, d::DatePart{'q'}, dt)
-        print(io, string(quarter(dt)))
+        print(io, string(quarterofyear(dt)))
     end
 
     function parse_quarterly(str::AbstractString)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,7 @@ replstr(x, kv::Pair...) = sprint((io,x) -> show(IOContext(io, :limit => true, :d
 
 # print
 @test replstr([MonthlyDate(1990, 1)]) == "1-element $(string(Array{MonthlyDate,1})):\n 1990-01"
+@test Dates.format(MonthlyDate(1990, 3), dateformat"Y-mm") == "1990-03"
 
 
 # parse
@@ -75,7 +76,7 @@ replstr(x, kv::Pair...) = sprint((io,x) -> show(IOContext(io, :limit => true, :d
 io = IOBuffer()
 df = (x = [MonthlyDate(1990, 1), MonthlyDate(1990, 2)], )
 CSV.write(io, df) 
-String(take!(io)) == "x\n1990-01\n1990-02\n"
+@test String(take!(io)) == "x\n1990-01\n1990-02\n"
 ##############################################################################
 ##
 ## QuarterlyDate
@@ -123,14 +124,19 @@ String(take!(io)) == "x\n1990-01\n1990-02\n"
 @test replstr([QuarterlyDate(1990, 1)]) == "1-element $(string(Array{QuarterlyDate,1})):\n 1990-Q1"
 
 # parse
-@test QuarterlyDate("1990-01") == QuarterlyDate(1990, 1)
+@test QuarterlyDate("1990-07") == QuarterlyDate(1990, 3)
+@test QuarterlyDate("1990-Q2") == QuarterlyDate(1990, 2)
 @test QuarterlyDate("1990/01", "y/m") == QuarterlyDate(1990, 1)
 @test QuarterlyDate("1990m01", dateformat"y\mm") == QuarterlyDate(1990, 1)
+@test QuarterlyDate("1990m07", dateformat"y\mm") == QuarterlyDate(1990, 3)
+@test QuarterlyDate("1990-03", dateformat"y-q") == QuarterlyDate(1990, 3)
 
+# formater
+@test Dates.format(QuarterlyDate(1990, 3), dateformat"Y-\Qq") == "1990-Q3"
 
 
 # csv
 io = IOBuffer()
 df = (x = [QuarterlyDate(1990, 1), QuarterlyDate(1990, 2)], )
 CSV.write(io, df) 
-String(take!(io)) == "x\n1990-01\n1990-04\n"
+@test String(take!(io)) == "x\n1990-Q1\n1990-Q2\n"


### PR DESCRIPTION
Separate #5 into two PR (thanks for the suggestion). This one is for parsing strings to QuarterlyDate.

Parsing is implemented with APIs from `Dates`,  by adding another token 'q' for quarters.

By default if no `DateFormat` (or formatting strings) is explicitly supplied, the string will be parsed by `dateformat"y-\Qq"` if the string contains char 'Q', and parsed by `ISODateFormat` otherwise.

When `DateFormat` is passed to `QuarterlyDate`,  if the format contains `q` (e.g. `"y-q"`), strings will be parsed as `QuarterlyDate` directly, if not (e.g. `"y-m"`), it'll be parsed as `Date` first and then converted to `QuarterlyDate`. i.e.

```
	julia> dtq = QuarterlyDate("1990-1", "Y-q")
	# 1990q1
	julia> QuarterlyDate("1990-4","Y-m") 
	# 1990q2
```

I noticed in `runtest.jl` there are examples of the second usage without `'q'`. Not sure anyone has used it but it seems better to keep this behavior.

Also, I removed the lines exporting `quarter`. Thanks for pointing it out. `quarter` needs to be defined in the package for formatting.

